### PR TITLE
ob_flush only if outputbuffer is on

### DIFF
--- a/src/SSE.php
+++ b/src/SSE.php
@@ -19,7 +19,9 @@ class SSE
     {
         while (true) {
             echo $this->event->fill();
-            ob_flush();
+            if(ob_get_level() > 0) {
+                ob_flush();
+            }
             flush();
             // if the connection has been closed by the client we better exit the loop
             if (connection_aborted()) {


### PR DESCRIPTION
I tried this with symfony (blank project started with `composer create-project symfony/website-skeleton sse`) but with debug on symfony turns notices into ErrorExceptions (https://symfony.com/doc/current/reference/configuration/framework.html#throw), thus causing the loop to end.

I'm not sure why ob is not started, but this ensures no ob_flush if it's not started.

If notices are turned into ErrorExceptions this is the exception we get:

Notice: ob_flush(): failed to flush buffer. No buffer to flush

This caused multiple requests to fire (each one succeeds, but we had to wait the reconnection_timeout) instead of one lasting connection.